### PR TITLE
フォームからProfyに登録したユーザーは必ずどこかのグループに属する事になります。

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ActiveRecord::Base
+end

--- a/db/migrate/20160924062048_create_groups.rb
+++ b/db/migrate/20160924062048_create_groups.rb
@@ -1,0 +1,5 @@
+class AddGroupIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :group_id, :integer
+  end
+end

--- a/db/migrate/20160924062151_add_group_id_to_users.rb
+++ b/db/migrate/20160924062151_add_group_id_to_users.rb
@@ -1,0 +1,4 @@
+class AddGroupIdToUsers < ActiveRecord::Migration
+  def change
+  end
+end

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
why: 誰がどのグループに所属しているのか記録するために、usersテーブル1レコードごとにグループ名を文字列で書いていくのは冗長ですよね。groupsテーブルを作成してusersテーブルとリレーションさせるようにしましょう。

what: usersテーブルにgroup_idを保存できるようにします。→グループモデルの作成、テーブルの作成
