### PR TITLE
ユーザーテーブルの情報に名前のカラムを増やす

### DIFF
--- a/db/migrate/20160925060450_add_column_to_users.rb
+++ b/db/migrate/20160925060450_add_column_to_users.rb
@@ -1,0 +1,8 @@
+class AddColumnToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :family_name, :string
+    add_column :users, :first_name, :string
+    add_column :users, :family_name_kana, :string
+    add_column :users, :first_name_kana, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160924062151) do
+ActiveRecord::Schema.define(version: 20160925060450) do
 
   create_table "groups", force: :cascade do |t|
     t.string   "key",        limit: 255
@@ -37,6 +37,10 @@ ActiveRecord::Schema.define(version: 20160924062151) do
     t.string   "unconfirmed_email",      limit: 255
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
+    t.string   "family_name",            limit: 255
+    t.string   "first_name",             limit: 255
+    t.string   "family_name_kana",       limit: 255
+    t.string   "first_name_kana",        limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
why:ユーザーテーブルにアドレスなどの最低限の情報しかないので名前の欄をつくる

what:ユーザーテーブルにfamily_nameなどの４つのstring形式のカラムを作成。migrateで反映
